### PR TITLE
refactor sections and add testing setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest --coverage"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -30,6 +31,9 @@
     "postcss": "^8.4.0",
     "autoprefixer": "^10.4.0",
     "eslint": "^8.57.0",
-    "eslint-config-next": "^14.2.0"
+    "eslint-config-next": "^14.2.0",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.2.0"
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=yeslinux-website
+sonar.organization=yeslinux
+sonar.sources=src
+sonar.tests=src
+sonar.test.inclusions=**/*.test.tsx
+sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -72,8 +72,8 @@ const AboutSection = () => {
               <div className="bg-darker/50 border border-primary/20 rounded-lg p-6 mt-8">
                 <h3 className="text-primary font-semibold text-lg mb-3">Nossa Missão</h3>
                 <p className="text-text-muted italic">
-                  "Tornar a segurança digital acessível através do software livre, 
-                  protegendo empresas e pessoas com soluções transparentes e inovadoras."
+                  &quot;Tornar a segurança digital acessível através do software livre, 
+                  protegendo empresas e pessoas com soluções transparentes e inovadoras.&quot;
                 </p>
               </div>
             </div>

--- a/src/components/sections/ServicesSection.tsx
+++ b/src/components/sections/ServicesSection.tsx
@@ -1,23 +1,17 @@
 'use client'
 
-const ServicesSection = () => {
-  return (
-    <section className="py-20 bg-darker">
-      <div className="container mx-auto px-4">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-5xl font-bold mb-6">
-            <span className="text-primary">Nossos</span> Serviços
-          </h2>
-          <p className="text-text-muted max-w-2xl mx-auto">
-            Soluções completas em segurança digital e software livre
-          </p>
-        </div>
-        <div className="text-center text-text-muted">
-          [Seção de Serviços será desenvolvida]
-        </div>
-      </div>
-    </section>
-  )
-}
+import Section from '../ui/Section'
+
+const ServicesSection = () => (
+  <Section
+    highlight="Nossos"
+    title="Serviços"
+    description="Soluções completas em segurança digital e software livre"
+  >
+    <div className="text-center text-text-muted">
+      [Seção de Serviços será desenvolvida]
+    </div>
+  </Section>
+)
 
 export default ServicesSection

--- a/src/components/sections/TerminalSection.tsx
+++ b/src/components/sections/TerminalSection.tsx
@@ -1,23 +1,17 @@
 'use client'
 
-const TerminalSection = () => {
-  return (
-    <section className="py-20 bg-darker">
-      <div className="container mx-auto px-4">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-5xl font-bold mb-6">
-            <span className="text-primary">YesLinux</span> Shell
-          </h2>
-          <p className="text-text-muted max-w-2xl mx-auto">
-            Explore nossa empresa através do terminal
-          </p>
-        </div>
-        <div className="text-center text-text-muted">
-          [Terminal Interativo será desenvolvido]
-        </div>
-      </div>
-    </section>
-  )
-}
+import Section from '../ui/Section'
+
+const TerminalSection = () => (
+  <Section
+    highlight="YesLinux"
+    title="Shell"
+    description="Explore nossa empresa através do terminal"
+  >
+    <div className="text-center text-text-muted">
+      [Terminal Interativo será desenvolvido]
+    </div>
+  </Section>
+)
 
 export default TerminalSection

--- a/src/components/ui/Section.test.tsx
+++ b/src/components/ui/Section.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import Section from './Section'
+
+describe('Section component', () => {
+  it('renders title, highlight, description and children', () => {
+    render(
+      <Section highlight="Test" title="Section" description="Description">
+        <div>Child content</div>
+      </Section>
+    )
+
+    expect(screen.getByText('Test')).toBeInTheDocument()
+    expect(screen.getByText('Section')).toBeInTheDocument()
+    expect(screen.getByText('Description')).toBeInTheDocument()
+    expect(screen.getByText('Child content')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+interface SectionProps {
+  id?: string
+  highlight: string
+  title: string
+  description: string
+  children?: React.ReactNode
+}
+
+const Section: React.FC<SectionProps> = ({ id, highlight, title, description, children }) => (
+  <section id={id} className="py-20 bg-darker">
+    <div className="container mx-auto px-4">
+      <div className="text-center mb-16">
+        <h2 className="text-3xl md:text-5xl font-bold mb-6">
+          <span className="text-primary">{highlight}</span> {title}
+        </h2>
+        <p className="text-text-muted max-w-2xl mx-auto">{description}</p>
+      </div>
+      {children}
+    </div>
+  </section>
+)
+
+export default Section

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "es6"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es6"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -20,13 +24,33 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@/components/*": ["./src/components/*"],
-      "@/lib/*": ["./src/lib/*"],
-      "@/hooks/*": ["./src/hooks/*"],
-      "@/types/*": ["./src/types/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ],
+      "@/components/*": [
+        "./src/components/*"
+      ],
+      "@/lib/*": [
+        "./src/lib/*"
+      ],
+      "@/hooks/*": [
+        "./src/hooks/*"
+      ],
+      "@/types/*": [
+        "./src/types/*"
+      ]
+    },
+    "types": [
+      "vitest/globals"
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+    coverage: {
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage'
+    }
+  }
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'


### PR DESCRIPTION
## Summary
- extract reusable Section component to remove duplicated markup
- configure testing and sonarcloud settings
- fix lint issues and ensure consistent styling

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b12b49dbc4832fa2b1fd64ef912c58