### PR TITLE
fix: non-interactive Vercel deploy and Codecov conditional

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         vercel-token: ${{ secrets.VERCEL_TOKEN }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        vercel-args: '--prod'
+        vercel-args: '--prod --yes'
         vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
         vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
         working-directory: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     strategy:
       matrix:
@@ -40,10 +42,8 @@ jobs:
       run: npm test
 
     - name: Upload coverage to Codecov
-      if: matrix.node-version == '20.x' && secrets.CODECOV_TOKEN != ''
+      if: matrix.node-version == '20.x' && env.CODECOV_TOKEN != ''
       uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: ./coverage/lcov.info
         flags: unittests


### PR DESCRIPTION
## Summary
- avoid Vercel CLI prompt by forcing non-interactive deploy
- guard Codecov upload step using env variable instead of secrets context

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b31872d998832f9dc70512a06b5ab0