### PR TITLE
fix: restore home page layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,21 @@
-import HeroSection from '@/components/sections/HeroSection'
 import AboutSection from '@/components/sections/AboutSection'
-import ServicesSection from '@/components/sections/ServicesSection'
 import BlogSection from '@/components/sections/BlogSection'
 import ContactSection from '@/components/sections/ContactSection'
-import LoadingSpinner from '@/components/ui/LoadingSpinner'
+import GamificationSection from '@/components/sections/GamificationSection'
+import HeroSection from '@/components/sections/HeroSection'
+import MatrixRain from '@/components/ui/MatrixRain'
+import ServicesSection from '@/components/sections/ServicesSection'
+import TerminalSection from '@/components/sections/TerminalSection'
 
 export default function HomePage() {
   return (
-    <main>
+    <main className="relative">
+      <MatrixRain />
       <HeroSection />
       <AboutSection />
       <ServicesSection />
+      <TerminalSection />
+      <GamificationSection />
       <BlogSection />
       <ContactSection />
     </main>


### PR DESCRIPTION
## Summary
- reintroduce MatrixRain background
- add Terminal and Gamification sections back to home page
- sort section imports for consistency

## Testing
- `npm test` *(fails: Cannot find dependency '@vitest/coverage-v8')*
