### PR TITLE
fix: correct MatrixRain layering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ O formato é baseado em [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - PWA (Progressive Web App)
 - Integração com CMS headless
 
+### Corrigido
+- Corrigido z-index do efeito Matrix Rain que sobrepunha o conteúdo da página inicial
+
 ---
 
 ## [1.0.0] - 2025-08-29

--- a/src/components/ui/MatrixRain.test.tsx
+++ b/src/components/ui/MatrixRain.test.tsx
@@ -9,7 +9,7 @@ describe('MatrixRain', () => {
 
   it('has correct CSS classes for matrix background', () => {
     const html = renderToString(<MatrixRain />)
-    expect(html).toContain('fixed inset-0 pointer-events-none z-0 overflow-hidden')
+    expect(html).toContain('fixed inset-0 pointer-events-none -z-10 overflow-hidden')
   })
 
   it('is positioned as a fixed overlay', () => {
@@ -20,7 +20,7 @@ describe('MatrixRain', () => {
 
   it('has proper z-index for background positioning', () => {
     const html = renderToString(<MatrixRain />)
-    expect(html).toContain('z-0')
+    expect(html).toContain('-z-10')
   })
 
   it('is non-interactive with pointer-events-none', () => {

--- a/src/components/ui/MatrixRain.tsx
+++ b/src/components/ui/MatrixRain.tsx
@@ -59,13 +59,13 @@ const MatrixRain = () => {
     return () => window.removeEventListener('resize', handleResize)
   }, [])
 
-  return (
-    <div 
-      ref={containerRef}
-      className="fixed inset-0 pointer-events-none z-0 overflow-hidden"
-      aria-hidden="true"
-    />
-  )
-}
+    return (
+      <div
+        ref={containerRef}
+        className="fixed inset-0 pointer-events-none -z-10 overflow-hidden"
+        aria-hidden="true"
+      />
+    )
+  }
 
-export default MatrixRain
+  export default MatrixRain


### PR DESCRIPTION
## Summary
- ensure MatrixRain stays behind page content
- update MatrixRain tests for new z-index
- document MatrixRain z-index fix

## Testing
- `npx vitest run` *(fails: Cannot find dependency 'jsdom')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b38ded34bc832fa60e6ac89256b983